### PR TITLE
Added currency and edit to logs

### DIFF
--- a/GreaseMonkeyJournal.Api/Components/Layout/MainLayout.razor
+++ b/GreaseMonkeyJournal.Api/Components/Layout/MainLayout.razor
@@ -16,6 +16,9 @@
                 @AppSettingsOptions.Value.ApplicationTitle
             </a>
             <div class="navbar-nav ms-auto">
+                <a class="theme-toggle nav-icon-link" href="/settings" title="Settings">
+                    <i class="bi bi-gear"></i>
+                </a>
                 <button class="theme-toggle" @onclick="ToggleDarkMode" title="Toggle dark mode">
                     <i class="bi @(_isDarkMode ? "bi-sun" : "bi-moon")"></i>
                 </button>

--- a/GreaseMonkeyJournal.Api/Components/Pages/AddLogEntryDialog.razor
+++ b/GreaseMonkeyJournal.Api/Components/Pages/AddLogEntryDialog.razor
@@ -3,18 +3,18 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="addLogEntryModalLabel">Add Log Entry</h5>
+                <h5 class="modal-title" id="addLogEntryModalLabel">@DialogTitle</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" @onclick="CloseDialog"></button>
             </div>
 
             <div class="modal-body">
-                <EditForm Model="entry" OnValidSubmit="Add">
+                <EditForm Model="entry" OnValidSubmit="Save">
                     <DataAnnotationsValidator />
                     <ValidationSummary class="text-danger" />
 
                     <div class="mb-3">
                         <label for="vehicleSelect" class="form-label">Vehicle *</label>
-                        <select id="vehicleSelect" class="form-select" @bind="entry.VehicleId" required>
+                        <select id="vehicleSelect" class="form-select" @bind="SelectedVehicleId" required>
                             <option value="0">Select a vehicle...</option>
                             @if (Vehicles != null)
                             {
@@ -64,7 +64,7 @@
                     </div>
 
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-primary">Add</button>
+                        <button type="submit" class="btn btn-primary">@SaveButtonText</button>
                         <button type="button" class="btn btn-secondary" @onclick="CloseDialog">Cancel</button>
                     </div>
                 </EditForm>
@@ -84,6 +84,9 @@
     public IEnumerable<Vehicle>? Vehicles { get; set; } = new List<Vehicle>();
     private LogEntry entry = new() { Date = DateTime.Now };
     private Vehicle? selectedVehicle;
+    private bool IsEditMode => entry.Id > 0;
+    private string DialogTitle => IsEditMode ? "Edit Log Entry" : "Add Log Entry";
+    private string SaveButtonText => IsEditMode ? "Save Changes" : "Add";
 
     private int SelectedVehicleId
     {
@@ -98,8 +101,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (LogEntry is not null)
-            entry = LogEntry;
         if (VehicleId > 0)
         {
             var vehicle = await VehicleService.GetByIdAsync(VehicleId);
@@ -114,6 +115,13 @@
         {
             Vehicles = await VehicleService.GetAllAsync();
         }
+
+        SetEntryFromParameters();
+    }
+
+    protected override void OnParametersSet()
+    {
+        SetEntryFromParameters();
     }
 
     public async Task ShowModal()
@@ -131,13 +139,40 @@
         };
     }
 
-    private async Task Add()
+    private async Task Save()
     {
         if (entry.VehicleId > 0 && !string.IsNullOrWhiteSpace(entry.Description) && !string.IsNullOrWhiteSpace(entry.Type))
         {
             await OnLogEntryAdded.InvokeAsync(entry);
             await CloseDialog();
         }
+    }
+    private void SetEntryFromParameters()
+    {
+        if (LogEntry is not null)
+        {
+            entry = new LogEntry
+            {
+                Id = LogEntry.Id,
+                VehicleId = LogEntry.VehicleId,
+                Date = LogEntry.Date,
+                Description = LogEntry.Description,
+                Cost = LogEntry.Cost,
+                Type = LogEntry.Type,
+                Notes = LogEntry.Notes,
+                SpeedometerReading = LogEntry.SpeedometerReading
+            };
+        }
+        else
+        {
+            entry = new LogEntry
+            {
+                Date = DateTime.Now,
+                VehicleId = VehicleId > 0 ? VehicleId : 0
+            };
+        }
+
+        selectedVehicle = Vehicles?.FirstOrDefault(v => v.Id == entry.VehicleId);
     }
 
     private async Task CloseDialog()

--- a/GreaseMonkeyJournal.Api/Components/Pages/Settings.razor
+++ b/GreaseMonkeyJournal.Api/Components/Pages/Settings.razor
@@ -1,0 +1,84 @@
+@page "/settings"
+@using GreaseMonkeyJournal.Api.Components.Services
+
+<PageTitle>Settings</PageTitle>
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12 col-lg-8 col-xl-6">
+            <div class="card fade-in">
+                <div class="card-header">
+                    <h5 class="card-title mb-0"><i class="bi bi-gear me-2"></i>Settings</h5>
+                </div>
+                <div class="card-body">
+                    <EditForm Model="this" OnValidSubmit="SaveSettingsAsync">
+                        <div class="mb-3">
+                            <label for="currencyCode" class="form-label">Currency for costs</label>
+                            <select id="currencyCode" class="form-select" @bind="currencyCode">
+                                @foreach (var currency in CurrencyOptions)
+                                {
+                                    <option value="@currency.Code">@currency.Label</option>
+                                }
+                            </select>
+                            <div class="form-text">This currency is used when showing maintenance and repair costs.</div>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Save Settings</button>
+                    </EditForm>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (showSuccessMessage)
+{
+    <div class="position-fixed top-0 end-0 p-3" style="z-index: 11">
+        <div class="toast show" role="alert">
+            <div class="toast-header bg-success text-white">
+                <i class="bi bi-check-circle me-2"></i>
+                <strong class="me-auto">Success</strong>
+                <button type="button" class="btn-close btn-close-white" @onclick="() => showSuccessMessage = false"></button>
+            </div>
+            <div class="toast-body">
+                Settings saved.
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Inject] private IUserSettingsService UserSettingsService { get; set; } = default!;
+
+    private string currencyCode = "USD";
+    private bool showSuccessMessage;
+
+    private static readonly List<CurrencyOption> CurrencyOptions =
+    [
+        new("USD", "USD ($)"),
+        new("EUR", "EUR (€)"),
+        new("GBP", "GBP (£)"),
+        new("SEK", "SEK (kr)")
+    ];
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        currencyCode = await UserSettingsService.GetCurrencyCodeAsync();
+        StateHasChanged();
+    }
+
+    private async Task SaveSettingsAsync()
+    {
+        await UserSettingsService.SetCurrencyCodeAsync(currencyCode);
+
+        showSuccessMessage = true;
+        StateHasChanged();
+        await Task.Delay(2500);
+        showSuccessMessage = false;
+        StateHasChanged();
+    }
+
+    private record CurrencyOption(string Code, string Label);
+}

--- a/GreaseMonkeyJournal.Api/Components/Pages/VehicleLog.razor
+++ b/GreaseMonkeyJournal.Api/Components/Pages/VehicleLog.razor
@@ -2,6 +2,7 @@
 @page "/vehicle/logs"
 @using GreaseMonkeyJournal.Api.Components.Models
 @using GreaseMonkeyJournal.Api.Components.Services
+@using System.Globalization
 
 <PageTitle>Vehicle Log Entries</PageTitle>
 
@@ -31,6 +32,7 @@
                                         <th>Cost</th>
                                         <th>Reading</th>
                                         <th>Notes</th>
+                                        <th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -45,9 +47,14 @@
                                                     @entry.Type
                                                 </span>
                                             </td>
-                                            <td>@entry.Cost.ToString("C")</td>
+                                            <td>@FormatCurrency(entry.Cost)</td>
                                             <td>@GetSpeedometerReadingDisplay(entry)</td>
                                             <td>@entry.Notes</td>
+                                            <td>
+                                                <button type="button" class="btn btn-sm btn-outline-primary" @onclick="() => ShowEditDialog(entry)">
+                                                    <i class="bi bi-pencil me-1"></i>Edit
+                                                </button>
+                                            </td>
                                         </tr>
                                     }
                                 </tbody>
@@ -71,6 +78,7 @@
 {
     <AddLogEntryDialog 
         @ref="dialogComponent"
+        LogEntry="selectedEntry"
         VehicleId="@(vehicleId ?? 0)" 
         OnLogEntryAdded="HandleLogEntryAdded" 
         OnClosed="HandleDialogClosed" />
@@ -97,6 +105,7 @@
     [Inject] private ILogEntryService LogEntryService { get; set; } = default!;
     [Inject] private IVehicleService VehicleService { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private IUserSettingsService UserSettingsService { get; set; } = default!;
 
     private IEnumerable<LogEntry> logEntries = new List<LogEntry>();
     private bool IsSingleMode => vehicleId.HasValue;
@@ -104,14 +113,46 @@
     private bool showSuccessMessage = false;
     private string successMessage = "";
     private AddLogEntryDialog? dialogComponent;
+    private LogEntry? selectedEntry;
+    private string currencyCode = "USD";
+    private static readonly Dictionary<string, string> CurrencyCultureMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["USD"] = "en-US",
+        ["EUR"] = "de-DE",
+        ["GBP"] = "en-GB",
+        ["SEK"] = "sv-SE"
+    };
 
     protected override async Task OnInitializedAsync()
     {
         logEntries = await GetLogEntriesAsync();
+        currencyCode = await UserSettingsService.GetCurrencyCodeAsync();
     }
 
     private async Task ShowAddDialog()
     {
+        selectedEntry = null;
+        showDialog = true;
+        StateHasChanged();
+        if (dialogComponent != null)
+        {
+            await dialogComponent.ShowModal();
+        }
+    }
+    private async Task ShowEditDialog(LogEntry entry)
+    {
+        selectedEntry = new LogEntry
+        {
+            Id = entry.Id,
+            VehicleId = entry.VehicleId,
+            Date = entry.Date,
+            Description = entry.Description,
+            Cost = entry.Cost,
+            Type = entry.Type,
+            Notes = entry.Notes,
+            SpeedometerReading = entry.SpeedometerReading
+        };
+
         showDialog = true;
         StateHasChanged();
         if (dialogComponent != null)
@@ -122,9 +163,17 @@
 
     private async Task HandleLogEntryAdded(LogEntry newEntry)
     {
-        await LogEntryService.AddAsync(newEntry);
+        if (newEntry.Id > 0)
+        {
+            await LogEntryService.UpdateAsync(newEntry);
+            successMessage = "Log entry updated successfully!";
+        }
+        else
+        {
+            await LogEntryService.AddAsync(newEntry);
+            successMessage = "Log entry created successfully!";
+        }
         logEntries = await GetLogEntriesAsync();
-        successMessage = "Log entry created successfully!";
         showSuccessMessage = true;
         StateHasChanged();
         await Task.Delay(3000);
@@ -135,6 +184,7 @@
     private void HandleDialogClosed()
     {
         showDialog = false;
+        selectedEntry = null;
         StateHasChanged();
     }
 
@@ -156,5 +206,13 @@
             return $"{logEntry.SpeedometerReading:N0} {unit}";
         }
         return "N/A";
+    }
+
+    private string FormatCurrency(decimal amount)
+    {
+        if (!CurrencyCultureMap.TryGetValue(currencyCode, out var cultureName))
+            cultureName = "en-US";
+
+        return amount.ToString("C", CultureInfo.GetCultureInfo(cultureName));
     }
 }

--- a/GreaseMonkeyJournal.Api/Components/Services/IUserSettingsService.cs
+++ b/GreaseMonkeyJournal.Api/Components/Services/IUserSettingsService.cs
@@ -1,0 +1,7 @@
+namespace GreaseMonkeyJournal.Api.Components.Services;
+
+public interface IUserSettingsService
+{
+    Task<string> GetCurrencyCodeAsync();
+    Task SetCurrencyCodeAsync(string currencyCode);
+}

--- a/GreaseMonkeyJournal.Api/Components/Services/UserSettingsService.cs
+++ b/GreaseMonkeyJournal.Api/Components/Services/UserSettingsService.cs
@@ -1,0 +1,50 @@
+using Microsoft.JSInterop;
+
+namespace GreaseMonkeyJournal.Api.Components.Services;
+
+public class UserSettingsService : IUserSettingsService
+{
+    private readonly IJSRuntime _jsRuntime;
+    private const string CurrencyCodeKey = "currencyCode";
+    private const string DefaultCurrencyCode = "USD";
+    private static readonly HashSet<string> SupportedCurrencyCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "USD",
+        "EUR",
+        "GBP",
+        "SEK"
+    };
+
+    public UserSettingsService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<string> GetCurrencyCodeAsync()
+    {
+        try
+        {
+            var storedCurrencyCode = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", CurrencyCodeKey);
+            if (string.IsNullOrWhiteSpace(storedCurrencyCode))
+                return DefaultCurrencyCode;
+
+            return SupportedCurrencyCodes.Contains(storedCurrencyCode) ? storedCurrencyCode.ToUpperInvariant() : DefaultCurrencyCode;
+        }
+        catch
+        {
+            return DefaultCurrencyCode;
+        }
+    }
+
+    public async Task SetCurrencyCodeAsync(string currencyCode)
+    {
+        if (string.IsNullOrWhiteSpace(currencyCode))
+            throw new ArgumentException("Currency code cannot be empty.", nameof(currencyCode));
+
+        var normalizedCurrencyCode = currencyCode.ToUpperInvariant();
+        if (!SupportedCurrencyCodes.Contains(normalizedCurrencyCode))
+            throw new ArgumentException("Unsupported currency code.", nameof(currencyCode));
+
+        await _jsRuntime.InvokeVoidAsync("localStorage.setItem", CurrencyCodeKey, normalizedCurrencyCode);
+    }
+}

--- a/GreaseMonkeyJournal.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/GreaseMonkeyJournal.Api/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,9 @@ public static class ServiceCollectionExtensions
         
         // Register reminder services (depends on ILogEntryService)
         services.AddScoped<IReminderService, ReminderService>();
+
+        // Register user settings service
+        services.AddScoped<IUserSettingsService, UserSettingsService>();
         
         return services;
     }

--- a/GreaseMonkeyJournal.Api/wwwroot/css/site.css
+++ b/GreaseMonkeyJournal.Api/wwwroot/css/site.css
@@ -164,6 +164,13 @@ h1, h2, h3, h4, h5, h6, .navbar-brand {
     color: var(--warning-color);
 }
 
+.nav-icon-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+}
+
 /* Responsive navbar assets */
 @media (max-width: 768px) {
     .hero-logo { height: 60px; max-width: 90px; }


### PR DESCRIPTION
This pull request introduces user-configurable currency settings and adds support for editing log entries in the vehicle log. It also improves the UI by adding a settings page, updating the main layout with a settings link, and refining the log entry dialog for both add and edit scenarios. The most significant changes are grouped below.

**User Settings and Currency Formatting:**

* Added a new `Settings` page (`Settings.razor`) where users can select their preferred currency for cost display. The selection is persisted using a new `UserSettingsService` that stores the preference in local storage. Currency formatting in the vehicle log now respects the user's chosen currency. [[1]](diffhunk://#diff-f35fa2bb1347d8dc58edc78a61b0cdfadc2306b20a8e524e01ff4dc96f4401b3R1-R84) [[2]](diffhunk://#diff-28dd9e2975385fa950f7f7ed6540d0bdc9010b45f534712d9b1f50360ffd2a1fR1-R7) [[3]](diffhunk://#diff-6ce47629ab19237b19fb1d1fefd852256084fd6af221c8c293e178a3a9dc08c6R1-R50) [[4]](diffhunk://#diff-e3b6de953ef7aa6fff4b3110634468088807b90055e61cbb9da009b52bd789d8R28-R30) [[5]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R108-R155) [[6]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R210-R217)
* Introduced a settings (gear) icon in the main navigation bar linking to the new settings page.
* Updated CSS to style navigation icons consistently.

**Vehicle Log Entry Editing:**

* Enhanced the vehicle log to support editing existing log entries. An "Edit" button now appears in each row, opening the dialog pre-filled with entry data. The dialog and backend logic distinguish between add and edit operations. [[1]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R35) [[2]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698L48-R57) [[3]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R81) [[4]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R108-R155) [[5]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R165-R176) [[6]](diffhunk://#diff-e91a3f9043865c095d651099fb0cc8fa92d665b5558e5bc21bd6b117aa15d698R187)
* Refactored `AddLogEntryDialog.razor` to support both adding and editing: dynamic dialog title/button, improved parameter handling, and logic to update entries when editing. [[1]](diffhunk://#diff-9ef6aaa2340c67918720f828a861690bdbe9998b5ae007c1ca02853b78b85d97L6-R17) [[2]](diffhunk://#diff-9ef6aaa2340c67918720f828a861690bdbe9998b5ae007c1ca02853b78b85d97L67-R67) [[3]](diffhunk://#diff-9ef6aaa2340c67918720f828a861690bdbe9998b5ae007c1ca02853b78b85d97R87-R89) [[4]](diffhunk://#diff-9ef6aaa2340c67918720f828a861690bdbe9998b5ae007c1ca02853b78b85d97L101-L102) [[5]](diffhunk://#diff-9ef6aaa2340c67918720f828a861690bdbe9998b5ae007c1ca02853b78b85d97R118-R124) [[6]](diffhunk://#diff-9ef6aaa2340c67918720f828a861690bdbe9998b5ae007c1ca02853b78b85d97L134-R176)

**Code Structure and Dependency Injection:**

* Registered the new `UserSettingsService` and its interface with the DI container for use throughout the application.

These changes collectively improve user experience by allowing customization of currency display, streamline log entry management, and provide a dedicated settings interface.